### PR TITLE
fix: gitlab credentials dialog disables the OK button if the username…

### DIFF
--- a/src/main/java/de/adito/nbm/ssp/auth/UserCredentialsDialog.java
+++ b/src/main/java/de/adito/nbm/ssp/auth/UserCredentialsDialog.java
@@ -94,7 +94,7 @@ public class UserCredentialsDialog extends JPanel
 
   public void addUsernameFieldDocumentListener(@NotNull DocumentListener pDocumentListener)
   {
-    passwordField.getDocument().addDocumentListener(pDocumentListener);
+    usernameField.getDocument().addDocumentListener(pDocumentListener);
   }
 
 }

--- a/src/main/java/de/adito/nbm/ssp/auth/UserCredentialsManager.java
+++ b/src/main/java/de/adito/nbm/ssp/auth/UserCredentialsManager.java
@@ -57,8 +57,9 @@ public class UserCredentialsManager
         DialogDescriptor dialogDescriptor = new DialogDescriptor(borderPane, NbBundle.getMessage(UserCredentialsManager.class, "LBL.UserCredentialsManager.title"),
                                                                  true, buttons, buttons[0], DialogDescriptor.BOTTOM_ALIGN, null, null);
         dialogDescriptor.setValid(credentialsDialog.getPassword().length > 0 && credentialsDialog.getUsername().length() > 0);
-        credentialsDialog.addPasswordFieldDocumentListener(new UserCredentialsManager.CredentialsFieldListener(credentialsDialog, dialogDescriptor));
-        credentialsDialog.addUsernameFieldDocumentListener(new CredentialsFieldListener(credentialsDialog, dialogDescriptor));
+        CredentialsFieldListener isValidCredentialsListener = new CredentialsFieldListener(credentialsDialog, dialogDescriptor);
+        credentialsDialog.addPasswordFieldDocumentListener(isValidCredentialsListener);
+        credentialsDialog.addUsernameFieldDocumentListener(isValidCredentialsListener);
 
         Dialog dialog = DialogDisplayer.getDefault().createDialog(dialogDescriptor);
         dialog.setResizable(true);


### PR DESCRIPTION
… is set after the password